### PR TITLE
feat: add basic error telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+package-lock.json
+/dist/
+.env
+

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,19 @@
+import { api } from './api'
+
+let lastSend = 0
+
+function send(message: string) {
+  const now = Date.now()
+  if (now - lastSend < 15000) return
+  lastSend = now
+  api.post('/api/debugEcho', { message }).catch(() => {})
+}
+
+export function initLogger() {
+  window.addEventListener('error', e => {
+    send(e.message)
+  })
+  window.addEventListener('unhandledrejection', (e: PromiseRejectionEvent) => {
+    send(String(e.reason))
+  })
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import MapPage from './pages/Map'
 import Diag from './pages/Diag'
 import './i18n'
 import './styles.css'
+import { initLogger } from './lib/logger'
 
 const router = createBrowserRouter([
   { path: '/', element: <App />, children: [
@@ -30,3 +31,6 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     </QueryClientProvider>
   </React.StrictMode>
 )
+
+// initialize error logging
+initLogger()


### PR DESCRIPTION
## Summary
- add minimal logger capturing errors and rejections and reporting to `/api/debugEcho`
- initialize telemetry in app entry
- ignore generated and local environment files

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68986a630518832cb9da84f21cda2c40